### PR TITLE
typo uic.cfg template

### DIFF
--- a/z_wave_ts_silabs/processes.py
+++ b/z_wave_ts_silabs/processes.py
@@ -319,7 +319,7 @@ log:
   level: '${LOG_LEVEL}'
 mapdir: '${UAM_MAPDIR}'
 zpc:
-  inclusion_protocol_preference: '{PROTOCOL_PREF}'
+  inclusion_protocol_preference: '${PROTOCOL_PREF}'
   normal_tx_power_dbm: ${TX_POWER_DBM}
   rf_region: '${REGION}'
   serial: '${TTY}'


### PR DESCRIPTION
Configuration file was missing a dollar sign before $PROTOCOL_PREF