### PR TITLE
Tentative to fix CI issues

### DIFF
--- a/z_wave_ts_silabs/zwave_cli.py
+++ b/z_wave_ts_silabs/zwave_cli.py
@@ -53,9 +53,8 @@ class DevZwaveCli(DevZwave):
                self.telnet_client.write(bytes(f'{command}\n', encoding='ascii'))
           except BrokenPipeError:
                # Reconnect and retry on pipe error
-               self.telnet_client.close()
-               self.telnet_client = telnetlib.Telnet(self.wpk.hostname, '4901', 1)
-               self.telnet_client.write(bytes(f'{command}\n', encoding='ascii'))
+               self.stop()
+               self.start()
           
           # Wait for initial response - command echo
           response = ""

--- a/z_wave_ts_silabs/zwave_cli.py
+++ b/z_wave_ts_silabs/zwave_cli.py
@@ -47,7 +47,7 @@ class DevZwaveCli(DevZwave):
           :return: The response from the command
           """
           # clear any pending data
-          self.telnet_client.read_very_eager().decode('ascii', errors='ignore')
+          self.telnet_client.read_very_eager()
           # Send the command
           try:
                self.telnet_client.write(bytes(f'{command}\n', encoding='ascii'))

--- a/z_wave_ts_silabs/zwave_cli.py
+++ b/z_wave_ts_silabs/zwave_cli.py
@@ -36,13 +36,49 @@ class DevZwaveCli(DevZwave):
           self.telnet_client = None
 
      def _run_cmd(self, command: str) -> str:
+          """Execute a command and return the response.
+
+          1. Clears any pending data in the buffer.
+          2. Sends the command to the device.
+          3. Reads the response in 2 phases:
+               - First, wait for the command echo.
+               - Then, wait for the next prompt (">").
+          :param command: The command to execute
+          :return: The response from the command
+          """
+          # clear any pending data
+          self.telnet_client.read_very_eager().decode('ascii', errors='ignore')
+          # Send the command
           try:
-               self.telnet_client.write(bytes(f'{command}\n' ,encoding='ascii'))
-          except BrokenPipeError as e: # single retry of the command
+               self.telnet_client.write(bytes(f'{command}\n', encoding='ascii'))
+          except BrokenPipeError:
+               # Reconnect and retry on pipe error
                self.telnet_client.close()
                self.telnet_client = telnetlib.Telnet(self.wpk.hostname, '4901', 1)
-               self.telnet_client.write(bytes(f'{command}\n' ,encoding='ascii'))
-          return self.telnet_client.read_until(b'\n> ', timeout=1).decode('ascii')
+               self.telnet_client.write(bytes(f'{command}\n', encoding='ascii'))
+          
+          # Wait for initial response - command echo
+          response = ""
+          try:
+               # First read until we see our command echoed back
+               response += self.telnet_client.read_until(bytes(f'{command}\n', 'ascii'), timeout=1).decode('ascii')
+               
+               # Then read until the next prompt (">")
+               response += self.telnet_client.read_until(b'> ', timeout=1).decode('ascii')
+               
+               if command not in response or '> ' not in response:
+                    self.logger.debug(f'Command response not properly synchronized: {response}')
+                    # Might be reading problem, try to recover by reading all data (very_eager)
+                    extra = self.telnet_client.read_very_eager().decode('ascii', errors='ignore')
+                    if extra:
+                         response += extra
+                         self.logger.debug(f'Additional data: {extra}')
+                         
+          except Exception as e:
+               self.logger.debug(f'Exception in _run_cmd: {str(e)}')
+               response = ""
+          
+          return response
 
      def set_learn_mode(self) -> None:
           output = self._run_cmd(f'set_learn_mode')

--- a/z_wave_ts_silabs/zwave_cli.py
+++ b/z_wave_ts_silabs/zwave_cli.py
@@ -73,9 +73,16 @@ class DevZwaveCli(DevZwave):
                          response += extra
                          self.logger.debug(f'Additional data: {extra}')
                          
+          except BrokenPipeError as e:
+               # Connection closed, try to recover
+               self.stop()
+               self.start()
+
+          except UnicodeDecodeError as e:
+               raise Exception(f"UnicodeDecodeError: {e}") from e
+          
           except Exception as e:
-               self.logger.debug(f'Exception in _run_cmd: {str(e)}')
-               response = ""
+               raise Exception(f"Unexpected error: {e}") from e
           
           return response
 

--- a/z_wave_ts_silabs/zwave_cli.py
+++ b/z_wave_ts_silabs/zwave_cli.py
@@ -66,12 +66,12 @@ class DevZwaveCli(DevZwave):
                response += self.telnet_client.read_until(b'> ', timeout=1).decode('ascii')
                
                if command not in response or '> ' not in response:
-                    self.logger.debug(f'Command response not properly synchronized: {response}')
+                    self.logger.warning(f'Command response not properly synchronized: {response}')
                     # Might be reading problem, try to recover by reading all data (very_eager)
                     extra = self.telnet_client.read_very_eager().decode('ascii', errors='ignore')
                     if extra:
                          response += extra
-                         self.logger.debug(f'Additional data: {extra}')
+                         self.logger.warning(f'Additional data: {extra}')
                          
           except BrokenPipeError as e:
                # Connection closed, try to recover

--- a/z_wave_ts_silabs/zwave_cli.py
+++ b/z_wave_ts_silabs/zwave_cli.py
@@ -174,12 +174,19 @@ class DevZwaveLedBulb(DevZwaveCli):
 
 class DevZwaveMultilevelSensor(DevZwaveCli):
 
+     def start(self):
+          super().start()
+          self.disable_sleeping()
+     
      @classmethod
      def app_name(cls) -> AppName:
           return 'zwave_soc_multilevel_sensor'
 
      def enable_sleeping(self):
-          self._run_cmd('enable_sleeping')
+          self._run_cmd('sleeping enable')
+
+     def disable_sleeping(self):
+          self._run_cmd('sleeping disable')
      
      def send_battery_and_sensor_report(self):
           self._run_cmd('send_battery_and_sensor_report')
@@ -203,12 +210,19 @@ class DevZwavePowerStrip(DevZwaveCli):
 
 class DevZwaveSensorPIR(DevZwaveCli):
 
+     def start(self):
+          super().start()
+          self.disable_sleeping()
+     
      @classmethod
      def app_name(cls) -> AppName:
           return 'zwave_soc_sensor_pir'
 
      def enable_sleeping(self):
-          self._run_cmd('enable_sleeping')
+          self._run_cmd('sleeping enable')
+
+     def disable_sleeping(self):
+          self._run_cmd('sleeping disable')
      
      def battery_report(self):
           self._run_cmd('battery_report')


### PR DESCRIPTION
SWPROT-9436: Fix inconsistent command output in CLI

    Observed a bug where the output of a command was buffered and returned
    as output of the next command.
    Example:
    2025-04-08 11:32:04.023 DevZwaveDoorLockKeypad-1 DEBUG _run_cmd: get_dsk
    2025-04-08 11:32:05.025 DevZwaveDoorLockKeypad-1 DEBUG _run_cmd output: get_dsk
    2025-04-08 11:32:05.026 DevZwaveDoorLockKeypad-1 DEBUG _run_cmd: set_learn_mode
    2q025-04-08 11:32:05.102 DevZwaveDoorLockKeypad-1 DEBUG _run_cmd output:

    [I] 42032-00370-02109-57549-46761-28345-59600-29460

    >

    This might be because read_until method is based on
    read_lazy and doesn't have command output in buffer at the time of
    reading.
    This commit aim to fix this bug by splitting the read in 2 steps. In
    case the read isn't successful, we try to recover with eager read.

 SWPROT-9436: Update CLI sleeping control commands

    CLI commands to control sleep have changed from enable_sleeping ->
    sleeping enable.
    Also keep device awake if we start the CLI.