### PR TITLE
SWPROT-9463: disable pti zlf capture main

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 from setuptools import setup, find_packages
 
 NAME = "z_wave_ts_silabs"
-VERSION = "0.4.0"
+VERSION = "0.4.1"
 
 # To install the library, run the following
 #

--- a/z_wave_ts_silabs/session_context.py
+++ b/z_wave_ts_silabs/session_context.py
@@ -50,7 +50,7 @@ class SessionContext:
         # current_test_logdir is used by most classes to store logs, but also other files such as configuration files for ZPC.
         self.current_test_logdir: Path | None = None
 
-        # used in DevZwave devices to enable RTT logs and PTI traces.
-        self.current_test_rtt_enabled: bool = True
-        self.current_test_pti_enabled: bool = True
+        # can be used in DevZwave devices to enable RTT logs and PTI traces. For now only enabled manually for zniffer. Disabled for others by default.
+        self.current_test_rtt_enabled: bool = False
+        self.current_test_pti_enabled: bool = False
 


### PR DESCRIPTION
An issue was found in end device (doorlock) with CTT test LR_FailingInclusionWithoutAuthentication_Rev02 caused by PTI. 
Disable it for application, and instead use zniffer as an extra device to debug zwave pkt if needed. This will be introduced in a separate pr in zw-prot associated with same ticket hash (SWPROT:9463).