### PR TITLE
Add optional capture name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 from setuptools import setup, find_packages
 
 NAME = "z_wave_ts_silabs"
-VERSION = "0.4.2"
+VERSION = "0.4.3"
 
 # To install the library, run the following
 #

--- a/z_wave_ts_silabs/devices.py
+++ b/z_wave_ts_silabs/devices.py
@@ -496,14 +496,16 @@ class DevZwave(Device, metaclass=ABCMeta):
             return None
         return f"zw-{self.home_id}-{self.node_id:04}"
 
-    def start_zlf_capture(self) -> None:
-        self.wpk.start_pti_logger(self._name)
+    def start_zlf_capture(self, optional_capture_name: str | None = None) -> None:
+        capture_name = self._name if optional_capture_name is None else optional_capture_name
+        self.wpk.start_pti_logger(capture_name)
 
     def stop_zlf_capture(self) -> None:
         self.wpk.stop_pti_logger()
 
-    def start_log_capture(self) -> None:
-        self.wpk.start_rtt_logger(f"{self._name}_rtt")
+    def start_log_capture(self, optional_capture_name: str | None = None) -> None:
+        capture_name = self._name if optional_capture_name is None else optional_capture_name
+        self.wpk.start_rtt_logger(f"{capture_name}_rtt")
 
     def stop_log_capture(self) -> None:
         self.wpk.stop_rtt_logger()


### PR DESCRIPTION
this feature could later be used in smoke tests to get a `zniffer.zlf` and a `zniffer.pcap` file instead of `DevZnifferNcp-<ID>.zlf` and `DevZnifferNcp-<ID>.pcap` today.

It's purely a cosmetic PR