### PR TITLE
swprot-9722 fix unreachable boards on smoke tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 from setuptools import setup, find_packages
 
 NAME = "z_wave_ts_silabs"
-VERSION = "0.4.6"
+VERSION = "0.4.7"
 
 # To install the library, run the following
 #

--- a/z_wave_ts_silabs/fixtures.py
+++ b/z_wave_ts_silabs/fixtures.py
@@ -93,14 +93,9 @@ def device_factory(updated_session_ctxt: SessionContext, hw_cluster: DevCluster)
 
 
 @pytest.fixture(scope="function", autouse=True)
-def hw_cluster_neutralize_all_wpk(hw_cluster: DevCluster):
-    hw_cluster.neutralize_all_wpk()
-    yield
-
-
-@pytest.fixture(scope="function", autouse=True)
 def hw_cluster_free_all_wpk(hw_cluster: DevCluster):
     hw_cluster.free_all_wpk()
+    hw_cluster.parallel_command('clear_flash')
     yield
     hw_cluster.free_all_wpk()
 


### PR DESCRIPTION
The smoke tests were experiencing board unreachability issues, where WPK boards would become unresponsive during test execution, leading to test failures and unreliable check of the CLI. 

This PR reworks the check of the CLI, introduces retries and moves the flash clearing to the beginning of the each test. In addition, the clearing is done in parallel, which should improve the overall performance.